### PR TITLE
fixed missing trailing zeros on amount smaller than 0.1smr

### DIFF
--- a/src/ui/ui_common.c
+++ b/src/ui/ui_common.c
@@ -105,7 +105,7 @@ void format_value_full_decimals(char *s, const unsigned int n,
 
     // format 0,xxxxxx
     if (val < 1000000ull) {
-        snprintf(s, n, "0.%06u", (uint32_t) val);
+        snprintf(s, n, "0.%06u", (uint32_t)val);
         return;
     }
 

--- a/src/ui/ui_common.c
+++ b/src/ui/ui_common.c
@@ -105,7 +105,7 @@ void format_value_full_decimals(char *s, const unsigned int n,
 
     // format 0,xxxxxx
     if (val < 1000000ull) {
-        snprintf(s, n, "0.%s", buffer);
+        snprintf(s, n, "0.%06u", (uint32_t) val);
         return;
     }
 


### PR DESCRIPTION
changes format of snprintf from `0.%s` to `0.%06u` to have correct trailing zeros